### PR TITLE
Fix relative path issue

### DIFF
--- a/include/pipex.h
+++ b/include/pipex.h
@@ -6,7 +6,7 @@
 /*   By: jkhasiza <jkhasiza@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/08 20:34:41 by jkhasiza          #+#    #+#             */
-/*   Updated: 2024/03/08 18:33:16 by jkhasiza         ###   ########.fr       */
+/*   Updated: 2024/03/10 15:31:02 by jkhasiza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,7 +79,7 @@ void		init_data(t_data *data, char **envp);
 void		init_pipes(t_data *data);
 void		handle_read_redirection(t_data *data, int i);
 void		handle_write_redirection(t_data *data, int i);
-bool		set_arg_as_path(t_data *data, t_command *command);
+void		set_arg_as_path(t_data *data, t_command *command);
 t_command	*get_command(t_data *data, char *raw_command);
 
 #endif

--- a/src/utils/command.c
+++ b/src/utils/command.c
@@ -6,7 +6,7 @@
 /*   By: jkhasiza <jkhasiza@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/18 20:50:20 by jkhasiza          #+#    #+#             */
-/*   Updated: 2024/03/08 18:39:32 by jkhasiza         ###   ########.fr       */
+/*   Updated: 2024/03/10 15:36:40 by jkhasiza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,7 +55,8 @@ static void	set_command_path(t_data *data, t_command *command)
 	int		i;
 
 	i = -1;
-	if (set_arg_as_path(data, command))
+	set_arg_as_path(data, command);
+	if (chr_in('/', command->args[0]) == 1)
 		return ;
 	while (data->dirs[++i])
 	{

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -6,7 +6,7 @@
 /*   By: jkhasiza <jkhasiza@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/08 18:14:41 by jkhasiza          #+#    #+#             */
-/*   Updated: 2024/03/08 18:38:54 by jkhasiza         ###   ########.fr       */
+/*   Updated: 2024/03/10 15:36:26 by jkhasiza         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,14 +57,17 @@ void	handle_read_redirection(t_data *data, int i)
 	}
 }
 
-bool	set_arg_as_path(t_data *data, t_command *command)
+/*
+	Function sets command path based on recieved `command`
+	if first argument is a path. It modifies `command` struct
+	directly and if something fails, it exits program directly.
+*/
+void	set_arg_as_path(t_data *data, t_command *command)
 {
 	if (access(command->args[0], X_OK) == 0)
 	{
 		command->path = ft_strdup(command->args[0]);
 		if (!command->path)
 			exit_gracefully(data, MEMO_ERR);
-		return (true);
 	}
-	return (false);
 }


### PR DESCRIPTION
Relative path was not wrokin gproperly in one edge case where `./ls` was path to executable. If it's joined with one of the pathes, it would go to proper location which is `/usr/bin/.ls/` and it's valid. However, I had to only look at current directory.